### PR TITLE
Removes "authorization" from benefit language

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,7 @@ layout: default
 			certificate, to every workload in a modern
 			production environment. SPIFFE removes the
 			need for application-level authentication
-			and authorization and complex network-level
-			ACL configuration.
+			and complex network-level ACL configuration.
 
 			</p>
 			<p><a class="btn btn-primary btn-sm" href="{{ "/spiffe/" | prepend: site.baseurl }}" role="button">Learn More</a></p>


### PR DESCRIPTION
SPIFFE nor SPIRE reason about authorization, so this language should be removed.